### PR TITLE
chore (docs) remove —ergo flag from concerto validate command docs (#610)

### DIFF
--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -50,7 +50,6 @@ Options:
       --utcOffset   set UTC offset                                      [number]
       --offline     do not resolve external models    [boolean] [default: false]
       --functional  new validation API                [boolean] [default: false]
-      --ergo        validation and emit for Ergo      [boolean] [default: false]
 ```
 
 ### Example


### PR DESCRIPTION
Remove the `--ergo` flag from the `concerto-validate` documentation now that it is being [removed in Concerto](https://github.com/accordproject/concerto/pull/637)

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [x] Manual accessibility test performed
    - [x] Keyboard-only access, including forms
    - [x] Contrast at least WCAG Level A
    - [x] Appropriate labels, alt text, and instructions
