### PR TITLE
Docs for cli apply decorator

### DIFF
--- a/docs/design/specification/model-properties.md
+++ b/docs/design/specification/model-properties.md
@@ -60,8 +60,8 @@ The example below validates that a `String` variable starts with `abc`:
 
 ```  
   o String stringLengthWithMinMaxLength length=[1,100] // greater than or equal to 1 and less than or equal to 100
-  o String stringLengthWithMinLength range=[1,] // greater than or equal to 1
-  o String stringLengthWithMaxLength range=[,100] // less than or equal to 100
+  o String stringLengthWithMinLength length=[1,] // greater than or equal to 1
+  o String stringLengthWithMaxLength length=[,100] // less than or equal to 100
 ```
 
 `Double`, `Long` or `Integer` fields may include an optional range expression, which is used to validate the contents of the field. Both the lower and upper bound are optional, however at least one must be specified. The upper bound must be greater than or equal to the lower bound.

--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -288,7 +288,7 @@ Options:
 ```
 
 ## concerto decorate
-`concerto decorate` allows you to apply decorators and vocabularies to a model
+`concerto decorate` allows you to apply decorators and vocabularies to a list of models
 
 ```md
 concerto decorate 

--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -287,3 +287,25 @@ Options:
                                                       [boolean] [default: false]
 ```
 
+## concerto decorate
+`concerto decorate` allows you to apply decorators and vocabularies to a model
+
+```md
+concerto decorate 
+
+apply the decorators and vocabs to the target models from given list of dcs files and vocab files
+
+
+Options:
+      --models                 The file location of the source models
+                                                              [array] [required]
+      --decorator              The file location of decorators to be applied
+                                                                         [array] 
+      --vocabulary             The file location of vocabularies to be applied
+                                                                         [array]
+      --format                 The output format for models (cto or json)
+                                                         [string] [default: cto]
+      --output                 The output directory path where you want your
+                               generated models to be stored
+                                                                        [string]
+```


### PR DESCRIPTION
Added the documentation for cli `decorate` command


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
