### PR TITLE
feat(cli): added documentation for apply decorators

### DIFF
--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -287,3 +287,21 @@ Options:
                                                       [boolean] [default: false]
 ```
 
+## concerto decorate
+`concerto decorate` allows you to apply decorators and vocabularies to a list of models
+```md
+concerto decorate
+apply the decorators and vocabs to the target models from given list of dcs files and vocab files
+Options:
+      --models                 The file location of the source models
+                                                              [array] [required]
+      --decorator              The file location of decorators to be applied
+                                                                         [array]
+      --vocabulary             The file location of vocabularies to be applied
+                                                                         [array]
+      --format                 The output format for models (cto or json)
+                                                         [string] [default: cto]
+      --output                 The output directory path where you want your
+                               generated models to be stored
+                                                                        [string]
+```


### PR DESCRIPTION
Added documentation for adding decorators via cli

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
