### PR TITLE
docs(cli): update compile command for vocab autogen

### DIFF
--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -116,6 +116,7 @@ At the moment, the available target formats are as follows:
 - Mermaid: `concerto compile --model modelfile.cto --target Mermaid`
 - Markdown: `concerto compile --model modelfile.cto --target Markdown`
 - Rust: `concerto compile --model modelfile.cto --target Rust`
+- Vocabulary: `concerto compile --model modelfile.cto --target Vocabulary`
 
 ### Example
 For example, using the `compile` command to export the `clause.cto` file from a [Late Delivery and Penalty](https://github.com/accordproject/cicero-template-library/tree/master/src/latedeliveryandpenalty) clause into `Go Lang` format:

--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -115,8 +115,8 @@ At the moment, the available target formats are as follows:
 - OData: `concerto compile --model modelfile.cto --target OData`
 - Mermaid: `concerto compile --model modelfile.cto --target Mermaid`
 - Markdown: `concerto compile --model modelfile.cto --target Markdown`
-- Vocabulary: `concerto compile --model modelfile.cto --target Vocabulary`
 - Rust: `concerto compile --model modelfile.cto --target Rust`
+- Vocabulary: `concerto compile --model modelfile.cto --target Vocabulary`
 
 ### Example
 For example, using the `compile` command to export the `clause.cto` file from a [Late Delivery and Penalty](https://github.com/accordproject/cicero-template-library/tree/master/src/latedeliveryandpenalty) clause into `Go Lang` format:

--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -115,8 +115,8 @@ At the moment, the available target formats are as follows:
 - OData: `concerto compile --model modelfile.cto --target OData`
 - Mermaid: `concerto compile --model modelfile.cto --target Mermaid`
 - Markdown: `concerto compile --model modelfile.cto --target Markdown`
-- Rust: `concerto compile --model modelfile.cto --target Rust`
 - Vocabulary: `concerto compile --model modelfile.cto --target Vocabulary`
+- Rust: `concerto compile --model modelfile.cto --target Rust`
 
 ### Example
 For example, using the `compile` command to export the `clause.cto` file from a [Late Delivery and Penalty](https://github.com/accordproject/cicero-template-library/tree/master/src/latedeliveryandpenalty) clause into `Go Lang` format:


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #28 
<!--- Provide an overall summary of the pull request -->
Need vocabulary codegen info in cli concerto compile docs

### Related Issues
- Issue #28 

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
