### PR TITLE
Fix typo in ConcertoModel relationships page

### DIFF
--- a/docs/design/specification/model-relationships.md
+++ b/docs/design/specification/model-relationships.md
@@ -22,7 +22,7 @@ Relationships must be resolved to retrieve an instance of the object being refer
 
 A property of a class may be declared as a relationship using the `-->` syntax instead of the `o` syntax. The `o` syntax declares that the class contains (has-a) property of that type, whereas the `-->` syntax declares a typed pointer to an external identifiable instance.
 
-In this example, the model declares that an `Order` has-an array of reference to `OrderLines`. Deleting the `Order` has no impact on the `OrderLine`. When the `Order` is serialized the JSON only the IDs of the `OrderLines` are stored within the `Order`, not the `OrderLines` themselves.
+In this example, the model declares that an `Order` has-an array of reference to `OrderLines`. Deleting the `Order` has no impact on the `OrderLine`. When the `Order` is serialized to JSON only the IDs of the `OrderLines` are stored within the `Order`, not the `OrderLines` themselves.
 
 ```js
 asset OrderLine identified by orderLineId {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #https://github.com/accordproject/techdocs/issues/350
<!--- Provide an overall summary of the pull request -->
This is a pull request regarding an issue in the [techdocs](https://github.com/accordproject/techdocs) repository. The issue describes two typos, the second one has already been fixed, this pull request fixes the other typo as well.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Fix typo: When the Order is serialized the JSON only the IDs of the OrderLines are stored within the Order, not the OrderLines themselves -> When the Order is serialized to JSON only the IDs of the OrderLines are stored within the Order, not the OrderLines themselves.

### Related Issues
- Issue https://github.com/accordproject/techdocs/issues/350

### Author Checklist
- [X] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [X] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
