### PR TITLE
Fix broken link to full reference to the Concerto metamodel in Metamodel JSON page

### DIFF
--- a/docs/design/specification/model-metamodel.md
+++ b/docs/design/specification/model-metamodel.md
@@ -77,5 +77,5 @@ concept Person identified by email {
 }
 ```
 
-The full reference to the Concerto metamodel is available [online](https://github.com/accordproject/concerto/blob/main/packages/concerto-metamodel/lib/metamodel.cto).
+The full reference to the Concerto metamodel is available [online](https://github.com/accordproject/concerto-metamodel/blob/main/lib/metamodel.cto).
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #35 and #34 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Update the link at the bottom of this page: https://concerto.accordproject.org/docs/design/specification/model-metamodel/

### Related Issues
- Issue #35 
- Issue #34 

### Author Checklist
- [X] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [X] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
