### PR TITLE
docs: added restricted keys for term decorator

### DIFF
--- a/docs/design/vocabulary.md
+++ b/docs/design/vocabulary.md
@@ -90,6 +90,16 @@ declarations:
 
 As you can see in the vocabularies above, a vocabulary can supplement or override terms from a base vocabulary, as is the case of the `en-gb` vocabulary which redefines and adds terms specific to British English over the generic English `en` vocabulary.
 
+In addition to the default `@Term` annotation, the `@Term_{vocabularyKey}` annotation allows you to define terms using custom vocabulary keys, supporting multiple alternative vocabularies.
+
+To avoid conflicts in the generated vocabulary YAML, the following keys are restricted:
+
+```
+Namespace level: "namespace", "locale", "declarations"
+Declaration level: "properties", declaration’s own name (e.g., Vehicle, Color)
+Property level: property's own name (e.g., vin, weight)
+```
+
 ## Creating a boostrap Vocabulary file
 
 Use the following command to generate a bootstrap Vocabulary file in English Language. This file will give a boilerplate format for the Vocabulary YAML file. This file can be edited to any description that is required or any language that is required.


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> added restricted vocabulary keys for @Term_{vocabularyKey} to avoid conflicts in the generated vocabulary YAML

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request https://github.com/accordproject/concerto/pull/1004

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
