### PR TITLE
docs(convert-dcs): Add documentation for DCS conversion methods and CLI usage

### DIFF
--- a/docs/design/decoratorcommands.md
+++ b/docs/design/decoratorcommands.md
@@ -70,7 +70,7 @@ The Decorator Command Set below defines three decorator commands:
 2. Append the `@New` decorator to all properties of type `String`
 3. Upsert the `@Form("inputType", "textArea")` decorator to the `test.Person.bio` property
 
-Definition of Decorator Command Set:
+#### Definition of Decorator Command Set:
 
 ```json
 {
@@ -88,7 +88,6 @@ Definition of Decorator Command Set:
             "decorator" : {
                 "$class" : "concerto.metamodel@1.0.0.Decorator",
                 "name" : "Form",
-                "namespace" : "test@1.0.0",
                 "arguments" : [
                     {
                         "$class" : "concerto.metamodel@1.0.0.DecoratorString",
@@ -111,7 +110,6 @@ Definition of Decorator Command Set:
             "decorator" : {
                 "$class" : "concerto.metamodel@1.0.0.Decorator",
                 "name" : "New",
-                "namespace" : "test@1.0.0",
                 "arguments" : []
             }
         },
@@ -127,7 +125,6 @@ Definition of Decorator Command Set:
             "decorator" : {
                 "$class" : "concerto.metamodel@1.0.0.Decorator",
                 "name" : "Form",
-                "namespace" : "test@1.0.0",
                 "arguments" : [
                     {
                         "$class" : "concerto.metamodel@1.0.0.DecoratorString",
@@ -174,4 +171,112 @@ concept Person {
     @New
     o String ssn
 }
+```
+
+The same **[Decorator Command Set](#definition-of-decorator-command-set)** can also be expressed in the **YAML format**:
+
+```yaml
+decoratorCommandsVersion: 0.4.0
+name: web
+version: 1.0.0
+commands:
+  - action: UPSERT
+    target:
+      type: concerto.metamodel@1.0.0.StringProperty
+    decorator:
+      name: Form
+      arguments:
+        - type: String
+          value: inputType
+        - type: String
+          value: text
+  - action: APPEND
+    target:
+      type: concerto.metamodel@1.0.0.StringProperty
+    decorator:
+      name: New
+  - action: UPSERT
+    target:
+      namespace: test
+      declaration: Person
+      property: bio
+    decorator:
+      name: Form
+      arguments:
+        - type: String
+          value: inputType
+        - type: String
+          value: textArea
+```
+
+You can convert DCS between JSON and YAML formats using the **[Concerto CLI](/docs/tools/ref-concerto-cli.md#concerto-convert-dcs)**.
+
+### Quick Start: DCS Format Conversion
+
+Let's walk through a practical example of converting a Decorator Command Set from JSON to YAML format.
+
+**Step 1:** Create a sample DCS file `sample-dcs.json`:
+
+```json
+{
+  "$class": "org.accordproject.decoratorcommands@0.4.0.DecoratorCommandSet",
+  "name": "validation",
+  "version": "1.0.0",
+  "commands": [
+    {
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
+      "type": "UPSERT",
+      "target": {
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
+        "namespace": "test@1.0.0",
+        "declaration": "Person",
+        "type": "concerto.metamodel@1.0.0.StringProperty"
+      },
+      "decorator": {
+        "$class": "concerto.metamodel@1.0.0.Decorator",
+        "name": "Validate",
+        "arguments": [
+          {
+            "$class": "concerto.metamodel@1.0.0.DecoratorString",
+            "value": "required"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Step 2:** Convert to YAML using the CLI:
+
+```bash
+concerto convert-dcs --dcs sample-dcs.json --output sample-dcs.yaml
+```
+
+**Step 3:** The resulting `sample-dcs.yaml` file:
+
+```yaml
+decoratorCommandsVersion: 0.4.0
+name: validation
+version: 1.0.0
+commands:
+  - action: UPSERT
+    target:
+      namespace: test@1.0.0
+      declaration: Person
+      type: concerto.metamodel@1.0.0.StringProperty
+    decorator:
+      name: Validate
+      arguments:
+        - type: String
+          value: required
+          
+```
+
+Notice how the YAML format is more concise and readable, removing the verbose `$class` properties while maintaining the same functionality.
+
+**Note:** The conversion works in both directions. You can also convert YAML back to JSON:
+
+```bash
+concerto convert-dcs --dcs sample-dcs.yaml
 ```

--- a/docs/reference/api/ref-js-api.md
+++ b/docs/reference/api/ref-js-api.md
@@ -285,6 +285,8 @@ specific models.
             * [.falsyOrEqual(test, value)](#module_concerto-core.DecoratorManager.falsyOrEqual) ⇒ <code>Boolean</code>
             * [.applyDecorator(decorated, type, newDecorator)](#module_concerto-core.DecoratorManager.applyDecorator)
             * [.executeCommand(namespace, declaration, command)](#module_concerto-core.DecoratorManager.executeCommand)
+            * [.jsonToYaml(jsonInput)](#module_concerto-core.DecoratorManager.jsonToYaml) ⇒ <code>string</code>
+            * [.yamlToJson(yamlInput)](#module_concerto-core.DecoratorManager.yamlToJson) ⇒ <code>object</code>
         * [.Factory](#module_concerto-core.Factory)
             * [new Factory(modelManager)](#new_module_concerto-core.Factory_new)
             * _instance_
@@ -1159,6 +1161,8 @@ Utility functions to work with
     * [.falsyOrEqual(test, value)](#module_concerto-core.DecoratorManager.falsyOrEqual) ⇒ <code>Boolean</code>
     * [.applyDecorator(decorated, type, newDecorator)](#module_concerto-core.DecoratorManager.applyDecorator)
     * [.executeCommand(namespace, declaration, command)](#module_concerto-core.DecoratorManager.executeCommand)
+    * [.jsonToYaml(jsonInput)](#module_concerto-core.DecoratorManager.jsonToYaml) ⇒ <code>string</code>
+    * [.yamlToJson(yamlInput)](#module_concerto-core.DecoratorManager.yamlToJson) ⇒ <code>object</code>
 
 <a name="module_concerto-core.DecoratorManager.decorateModels"></a>
 
@@ -1214,6 +1218,32 @@ decorators to the ClassDeclaration, or its properties, as required.
 | namespace | <code>string</code> | the namespace for the declaration |
 | declaration | <code>\*</code> | the class declaration |
 | command | <code>\*</code> | the Command object from the org.accordproject.decoratorcommands model |
+
+<a name="module_concerto-core.DecoratorManager.jsonToYaml"></a>
+
+#### DecoratorManager.jsonToYaml(jsonInput) ⇒ <code>string</code>
+Converts DCS JSON object into YAML string.
+Validates the input DCS JSON against the DCS model.
+
+**Kind**: static method of [<code>DecoratorManager</code>](#module_concerto-core.DecoratorManager)  
+**Returns**: <code>string</code> - the corresponding YAML string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| jsonInput | <code>object</code> | the DCS JSON as parsed object |
+
+<a name="module_concerto-core.DecoratorManager.yamlToJson"></a>
+
+#### DecoratorManager.yamlToJson(yamlInput) ⇒ <code>object</code>
+Converts DCS YAML string into JSON object.
+Validates the output DCS JSON against the DCS model.
+
+**Kind**: static method of [<code>DecoratorManager</code>](#module_concerto-core.DecoratorManager)  
+**Returns**: <code>object</code> - the corresponding JSON object  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| yamlInput | <code>string</code> | the DCS YAML as string |
 
 <a name="module_concerto-core.Factory"></a>
 

--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -26,6 +26,9 @@ Commands:
   concerto compare            compare two Concerto model files
   concerto infer              generate a concerto model from a source schema
   concerto generate <mode>    generate a sample JSON object for a concept
+  concerto decorate           apply the decorators and vocabs to the target models from given list of dcs files and vocab files
+  concerto extract-decorators extract the decorator command sets and vocabularies from a list of model files
+  concerto convert-dcs        convert decorator command set between JSON and YAML formats
 
 Options:
       --version  Show version number                                   [boolean]
@@ -323,4 +326,44 @@ Options:
       --output                 The output directory path where you want your
                                generated models to be stored
                                                         [string] [default :output]
+```
+
+## concerto convert-dcs
+`concerto convert-dcs` allows you to convert Decorator Command Set files between JSON and YAML formats.
+
+```md
+concerto convert-dcs
+
+convert decorator command set between JSON and YAML formats
+
+Options:
+      --version  Show version number                                   [boolean]
+  -v, --verbose                                                 [default: false]
+      --help     Show help                                             [boolean]
+      --dcs      The input DCS file (.json or .yaml/.yml)    [string] [required]
+      --output   The output file path (.json or .yaml/.yml). If not provided,
+                 outputs to console                                     [string]
+```
+
+The command automatically detects the input format based on the file extension and converts to the opposite format:
+- `.json` files are converted to YAML format
+- `.yaml` or `.yml` files are converted to JSON format
+
+### Example
+Convert a JSON decorator command set to YAML:
+
+```
+concerto convert-dcs --dcs dcs.json --output dcs.yml
+```
+
+Convert a YAML decorator command set to JSON:
+
+```
+concerto convert-dcs --dcs dcs.yaml --output dcs.json
+```
+
+If no output file is specified, the converted content will be written to console:
+
+```
+concerto convert-dcs --dcs dcs.json
 ```


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #79
# Closes #77

This PR adds documentation for the new DCS conversion functionality to convert Decorator Command Sets between JSON and YAML formats both programmatically and via CLI.

### Changes Made

1. API Documentation (`docs/reference/api/ref-js-api.md`)
2. CLI Documentation (`docs/tools/ref-concerto-cli.md`)
3. Design Documentation (`docs/design/decoratorcommands.md`)

