### PR TITLE
docs(concerto-linter): add docs for linter and CLI commands

### DIFF
--- a/docs/design/concertolinter.md
+++ b/docs/design/concertolinter.md
@@ -1,0 +1,291 @@
+---
+id: concertolinter
+title: Concerto Linter
+sidebar_position: 6
+---
+
+A fully configurable linter for Concerto models that ensures best practices and high-quality standards before use. It runs models against a default ruleset, and you can customize it to fit your needs.
+
+It can be used programmatically as a library via its `lintModel` API or interactively through a Command-Line Interface (CLI) command integrated into the `concerto-cli`.
+
+## Programmatic Usage (`lintModel` API)
+
+Install the package via npm:
+
+```bash
+npm install @accordproject/concerto-linter
+```
+
+The `lintModel` function accepts your model in two formats.
+
+- Option 1 - CTO string
+
+```javascript
+import { lintModel } from "@accordproject/concerto-linter";
+
+const model = `
+namespace org.example
+
+asset MyProduct {
+  o String productId
+}
+`;
+
+const results = await lintModel(model);
+console.log(results);
+```
+
+- Option 2 - Parsed AST
+
+```javascript
+import { lintModel } from "@accordproject/concerto-linter";
+import { ModelManager } from "@accordproject/concerto-core";
+
+const modelManager = new ModelManager();
+const ctoString = `
+namespace org.example
+asset MyProduct {
+ o String productId
+}`;
+modelManager.addCTOModel(ctoString);
+
+const ast = modelManager.getAst();
+const results = await lintModel(ast);
+console.log(results);
+```
+
+### Ruleset Configuration
+
+You can control which Spectral rules are applied in several ways:
+
+- **Default Ruleset** - if no custom configuration is present, the linter uses the built-in `@accordproject/concerto-linter-default-ruleset`.
+- **Automatic discovery** - the linter searches for common Spectral configuration files in the project root: `.spectral.yaml`, `.spectral.yml`, `.spectral.json`, or `.spectral.js`.
+- **Explicit path** - pass a path to a custom ruleset file:
+
+```javascript
+const results = await lintModel(model, {
+  ruleset: "path/to/custom-ruleset.yaml",
+});
+```
+
+- **Force default** - use the literal string `'default'` to force the built-in ruleset even if custom rulesets exist:
+
+```javascript
+const results = await lintModel(model, { ruleset: "default" });
+```
+
+For instructions on authoring custom rulesets see the _Configuration & Extensibility_ section of the documentation.
+
+### Output format
+
+`lintModel` returns a `Promise` that resolves to an array of lint result objects. Each item describes a single issue using a flat JSON structure.
+
+```typescript
+interface lintResult {
+  /** Unique rule identifier (e.g. 'no-unused-concept') */
+  code: string;
+
+  /** Human-readable description of the violation */
+  message: string;
+
+  /** Severity level ('error' | 'warning' | 'info' | 'hint') */
+  severity: string;
+
+  /**
+   * JSONPath-style pointer as an array of keys/indices (e.g. ['declarations', 3])
+   */
+  path: Array<string | number>;
+
+  /** Namespace where the violation occurred (e.g. 'org.accordproject') */
+  namespace?: string;
+}
+```
+
+#### Example output
+
+```json
+[
+  {
+    "code": "camel-case-properties",
+    "message": "Property 'FirstVal' should be camelCase (e.g. 'firstVal').",
+    "severity": "warning",
+    "path": ["declarations", 3],
+    "namespace": "org.example.model"
+  }
+]
+```
+
+### Namespace filtering
+
+By default the linter excludes results from internal namespaces (for example `concerto.*` and `org.accordproject.*`). You can override or extend these exclusions with the `excludeNamespaces` option:
+
+```javascript
+// override default exclusions
+const results = await lintModel(ast, {
+  excludeNamespaces: ["org.example.*", "com.acme.*"],
+});
+
+// combine a custom ruleset and namespace filtering
+const results2 = await lintModel(ast, {
+  ruleset: "D:\\linter-test\\my-ruleset.yaml",
+  excludeNamespaces: ["org.example.*"],
+});
+```
+
+## Default Ruleset
+
+`@accordproject/concerto-linter-default-ruleset`
+
+A comprehensive set of linting rules designed to validate concerto models against industry best practices and consistent naming conventions. It is fully configurable - you can extend it, add new rules, disable existing ones, or create an entirely new ruleset without extending this one.
+
+This sub-package is part of the `@accordproject/concerto-linter` package.
+
+### Available Rules
+
+The following table provides an overview of the available linting rules in the default ruleset:
+
+| Rule Id                         | Description                                                                                                                                                                                                                                                 |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| namespace-version               | Ensures that the namespace declaration in the model includes a version number. This rule enforces semantic versioning in namespaces, promoting clarity and compatibility management.                                                                        |
+| no-reserved-keywords            | Enforces that names used for declarations, properties, and decorators in concerto models do not use reserved keywords. Reserved keywords are language-specific terms that may cause conflicts or unexpected behavior if used as identifiers.                |
+| pascal-case-declarations        | Ensures that declaration names (scalar, enum, concept, asset, participant, transaction, event) follow PascalCase naming convention (e.g., 'MyDeclaration'). This promotes consistency and readability across model declarations.                            |
+| camel-case-properties           | Ensures that properties of type String, Double, Integer, Long, DateTime, and Boolean are named using camelCase. This promotes consistency and readability in property naming conventions across the model.                                                  |
+| upper-snake-case-enum-constants | Enforces that all enum constant names follow the UPPER_SNAKE_CASE convention. This rule checks each enum property name and reports an error if it does not match the required pattern. Ensures consistency and readability in enum naming across the model. |
+| pascal-case-decorators          | Ensures that decorator names follow PascalCase naming convention (e.g., 'MyDecorator'). This promotes consistency and readability across model decorators.                                                                                                  |
+| string-length-validator         | Ensures that all string properties within the data model have a length validator applied, which helps prevent inconsistent data length and ensure proper storage.                                                                                           |
+| no-empty-declarations           | Detects and reports any model declarations that are empty. This rule helps maintain model integrity by ensuring that all declarations contain meaningful content, preventing the inclusion of unused or placeholder declarations in the model.              |
+| abstract-must-subclassed        | Ensures that every abstract declaration in the model has at least one concrete subclass. This helps prevent unused or orphaned abstract types, enforcing better model design.                                                                               |
+
+First, install the package as a development dependency:
+
+```bash
+npm install --save-dev @accordproject/concerto-linter-default-ruleset
+```
+
+Once installed, the default ruleset is automatically used by the concerto Linter when no custom ruleset is specified.
+
+```javascript
+import { lintModel } from "@accordproject/concerto-linter";
+
+// The default ruleset will be used automatically
+const results = await lintModel(modelText);
+console.log(results);
+```
+
+To explicitly specify the default ruleset:
+
+```javascript
+const results = await lintModel(modelText, { ruleset: "default" });
+```
+
+## Customization
+
+To create your own ruleset that fits your project needs, you can either extend the default ruleset, or create an entirely new ruleset from scratch.
+
+Your ruleset can be defined in multiple file formats (YAML, JSON, JavaScript). Below we show YAML examples only; other formats are supported but not shown here.
+
+### Extending the Default Ruleset
+
+You can extend the default ruleset. Rulesets can be authored in multiple formats; the YAML form is shown here.
+
+**YAML (.spectral.yaml)**
+
+```yaml
+extends: "@accordproject/concerto-linter-default-ruleset"
+```
+
+### Disabling Specific Rules
+
+You can disable specific rules that don't match your project's requirements by setting them to `'off'`. The rule identifiers are defined in the `ruleset-main.ts` file located at `concerto/packages/concerto-linter/default-ruleset/src`.
+
+#### Available Rule IDs
+
+| Rule ID                           | Description                                       |
+| --------------------------------- | ------------------------------------------------- |
+| `namespace-version`               | Ensures namespaces include version numbers        |
+| `no-reserved-keywords`            | Prevents use of reserved keywords                 |
+| `pascal-case-declarations`        | Enforces PascalCase for declarations              |
+| `camel-case-properties`           | Enforces camelCase for properties                 |
+| `upper-snake-case-enum-constants` | Enforces UPPER_SNAKE_CASE for enum constants      |
+| `pascal-case-decorators`          | Enforces PascalCase for decorators                |
+| `string-length-validator`         | Requires string length validators                 |
+| `no-empty-declarations`           | Prevents empty declarations                       |
+| `abstract-must-subclassed`        | Ensures abstract classes have concrete subclasses |
+
+You can express this configuration in YAML:
+
+**YAML (.spectral.yaml)**
+
+```yaml
+extends: "@accordproject/concerto-linter-default-ruleset"
+rules:
+  pascal-case-declarations: "off"
+  camel-case-properties: "off"
+```
+
+### Enabling Specific Rules
+
+You can selectively start with everything off and enable only specific rules :
+
+**YAML (.spectral.yaml)**
+
+```yaml
+extends: [["@accordproject/concerto-linter-default-ruleset", "off"]]
+rules:
+  pascal-case-declarations: true
+  namespace-version: true
+```
+
+---
+
+### Adjusting Rule Severity
+
+You can customize the severity level of each rule to control how violations are reported. Use textual levels (`error`, `warn`, `info`, `hint`) or numeric levels according to your project's conventions.
+
+- **error** = must be fixed
+- **warn** = should be addressed
+- **info** = useful information
+- **hint** = optional suggestion
+
+Below is a YAML example showing severity overrides :
+
+**YAML (.spectral.yaml)**
+
+```yaml
+extends: "@accordproject/concerto-linter-default-ruleset"
+rules:
+  pascal-case-declarations: "warn" # Change from error to warning
+  camel-case-properties: "info" # Change to informational
+```
+
+## Creating Custom Rules
+
+Whether you want to add new rules to the default ruleset or create an entirely new ruleset, you can follow the Spectral ruleset format. For comprehensive documentation, see the [Spectral ruleset documentation](https://meta.stoplight.io/docs/spectral/e5b9616d6d50c-rulesets).
+
+Here's a simple example of what a custom rule looks like (YAML):
+
+```yaml
+# description (optional): Explains what the ruleset is about.
+description: "Declaration names (scalar, enum, concept, asset, participant, transaction, event) should be PascalCase."
+
+# given (required): JSONPath expression that specifies where the rule applies.
+given: "$.models[*].declarations[*].name"
+
+# message (required): The error/warning message shown when the rule is violated.
+message: "Declaration '{{value}}' should be PascalCase (e.g. 'MyDeclaration')"
+
+# severity (optional): The level of violation.
+# 0 = error, 1 = warning, 2 = info, 3 = hint
+severity: 0
+
+# then (required): Defines what function to apply and how.
+then:
+  # function (required): The function that validates the rule.
+  function: casing
+
+  # functionOptions (optional): Extra options for the function.
+  functionOptions:
+    type: pascal
+```
+
+For more complex rules, you can create custom JavaScript functions following [Spectral ruleset documentation](https://meta.stoplight.io/docs/spectral/e5b9616d6d50c-rulesets) and import them into your rule, similar to how the built-in rules work.✅

--- a/docs/reference/api/ref-js-api.md
+++ b/docs/reference/api/ref-js-api.md
@@ -31,6 +31,10 @@ specific models.</p>
 <dd><p>Concerto vocabulary module. Concerto is a framework for defining domain
 specific models.</p>
 </dd>
+<dt><a href="#module_concerto-linter">concerto-linter</a></dt>
+<dd><p>Concerto linter module. Concerto is a framework for defining domain
+specific models.</p>
+</dd>
 </dl>
 
 ## Classes
@@ -3904,6 +3908,39 @@ vocabulary is found, null is returned
 | [options.localeMatcher] | <code>\*</code> | Pass 'lookup' to find a general vocabulary, if available |
 
 <a name="AbstractPlugin"></a>
+
+<a name="module_concerto-linter"></a>
+
+## concerto-linter
+Concerto linter module. Concerto is a framework for defining domain
+specific models.
+
+
+<a name="module_concerto-linter.lintModel"></a>
+
+### concerto-linter.lintModel(model, [config]) ⇒ <code>Promise.&lt;Array.&lt;lintResult&gt;&gt;</code>
+Lints Concerto models using Spectral and Concerto rules.
+
+**Kind**: static method of [<code>concerto-linter</code>](#module_concerto-linter)  
+**Returns**: <code>Promise.&lt;Array.&lt;lintResult&gt;&gt;</code> - A promise that resolves to an array of linting results.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| model | <code>string</code> \| <code>object</code> | The Concerto model to lint, either as a CTO string or a parsed AST object. Note: No external dependency resolution is performed. |
+| [config] | <code>object</code> | Configuration options for customizing the linting process. |
+| [config.ruleset] | <code>string</code> | Path to a custom Spectral ruleset file or 'default' to use the built-in ruleset. |
+| [config.excludeNamespaces] | <code>string</code> \| <code>Array.&lt;string&gt;</code> | One or more namespaces to exclude from linting results (defaults to 'concerto.*' and 'org.accord.*'). |
+
+
+**Result**: The returned `lintResult` objects have the following properties:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| code | <code>string</code> | Unique rule identifier (e.g. 'no-reserved-keywords') |
+| message | <code>string</code> | Human-readable description of the violation |
+| severity | <code>string</code> | Severity level ('error' \| 'warning' \| 'info' \| 'hint') |
+| path | <code>Array.&lt;string&nbsp;\|&nbsp;number&gt;</code> | JSONPath-style pointer as an array of keys/indices (e.g. ['declarations', 3]) |
+| namespace | <code>string</code> | Namespace where the violation occurred |
 
 ## AbstractPlugin
 Simple plug-in class for code-generation. This lists functions that can be passed to extend the default code-generation behavior.

--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -29,6 +29,7 @@ Commands:
   concerto decorate           apply the decorators and vocabs to the target models from given list of dcs files and vocab files
   concerto extract-decorators extract the decorator command sets and vocabularies from a list of model files
   concerto convert-dcs        convert decorator command set between JSON and YAML formats
+  concerto lint               lint concerto model file
 
 Options:
       --version  Show version number                                   [boolean]
@@ -366,4 +367,49 @@ If no output file is specified, the converted content will be written to console
 
 ```
 concerto convert-dcs --dcs dcs.json
+```
+
+## concerto lint
+`concerto lint` enables linting concerto models directly from the terminal. It helps developers validate models against default or custom rulesets.
+
+```md
+concerto lint
+
+lint concerto model file
+
+Options:
+      --version  Show version number                                   [boolean]
+  -v, --verbose                                                 [default: false]
+      --help     Show help                                             [boolean]
+      --model    Path to concerto model (CTO) files to lint. [array] [required]
+      --exclude  One or more namespaces to exclude from lint results. Defaults
+                 include `concerto.*` and `org.accordproject.*`.         [array]
+      -j         Output results in JSON format.                        [boolean]
+      --ruleset  Path to a custom Spectral ruleset file, or `'default'` to
+                 force the built-in ruleset.                            [string]
+```
+
+### Example
+Lint a model with default (text) output:
+
+```md
+concerto lint --model model.cto
+```
+
+Lint a model with JSON output:
+
+```md
+concerto lint --model model.cto -j
+```
+
+Lint a model excluding a specific namespace:
+
+```md
+concerto lint --model model.cto --exclude org.example
+```
+
+Lint a model using a custom ruleset:
+
+```md
+concerto lint --model model.cto --ruleset ./custom-ruleset.yaml
 ```

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -47,6 +47,7 @@ Commands:
   concerto decorate           apply the decorators and vocabs to the target models from given list of dcs files and vocab files
   concerto extract-decorators extract the decorator command sets and vocabularies from a list of model files
   concerto convert-dcs        convert decorator command set between JSON and YAML formats
+  concerto lint               lint concerto model file
 
 Options:
       --version  Show version number                                   [boolean]


### PR DESCRIPTION
This pull request introduces the documentation for the new Concerto Linter, a tool for ensuring best practices and high-quality standards for Concerto models.

The linter can be used programmatically via its `lintModel` API or interactively through the new `concerto lint` command in the Concerto CLI.

### Key Changes

- **Added New Linter Documentation:** A new file, `docs/design/concertolinter.md`, has been added.

- **Updated CLI Reference:** The file `docs/tools/ref-concerto-cli.md` has been updated to include the new `concerto lint` command.

- **Updated JavaScript API Reference:** The `docs/reference/api/ref-js-api.md` file has been updated to document the new `concerto-linter` module and its `lintModel` API.





### Author Checklist
- [X] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [X] Extend the documentation, if necessary
- [X] Merging to `master` from `Ahmed-Gaper/add-linter-docs`
