### PR TITLE
fix: update broken CLI documentation link in migration guide

### DIFF
--- a/docs/reference/migration/ref-migrate-concerto-2.0-3.0.md
+++ b/docs/reference/migration/ref-migrate-concerto-2.0-3.0.md
@@ -44,7 +44,7 @@ It is recommended that you migrate your CTO files to use versioned namespaces. I
 
 The `concerto-cli` command line utility has been improved and extended, with support for checking semver compatability of models, incrementing namespace versions, generating code from models, and parser performance improvements.
 
-Please see the updated [CLI documentation](ref-concerto-cli.md) for details.
+Please see the updated [CLI documentation](../../tools/ref-concerto-cli.md) for details.
 
 ## Core Enhancements
 


### PR DESCRIPTION
# Closes #91 

### Summary
This PR fixes a broken link in the "Concerto 2.0 to 3.0" migration guide that was leading to a 404 error. The link to the CLI documentation was pointing to an incorrect relative path.

### Changes
- Updated the "CLI documentation" link in [docs/reference/migration/ref-migrate-concerto-2.0-3.0.md](cci:7://file:///c:/Users/Lenovo/concerto-docs/docs/reference/migration/ref-migrate-concerto-2.0-3.0.md:0:0-0:0) to point to the correct location: `../../tools/ref-concerto-cli.md`.

### Flags
- None

### Screenshots or Video
Video identifying the issue:
https://github.com/user-attachments/assets/d5ec0e4c-68da-46fa-9867-1dc78272d176

### Related Issues
- Issue #91 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:fix/broken-cli-link`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions