### PR TITLE
fix(docs): repair broken CLI link in migration guide

### DIFF
--- a/docs/reference/migration/ref-migrate-concerto-2.0-3.0.md
+++ b/docs/reference/migration/ref-migrate-concerto-2.0-3.0.md
@@ -44,7 +44,7 @@ It is recommended that you migrate your CTO files to use versioned namespaces. I
 
 The `concerto-cli` command line utility has been improved and extended, with support for checking semver compatability of models, incrementing namespace versions, generating code from models, and parser performance improvements.
 
-Please see the updated [CLI documentation](ref-concerto-cli.md) for details.
+Please see the updated [CLI documentation](../../tools/ref-concerto-cli.md) for details.
 
 ## Core Enhancements
 


### PR DESCRIPTION
Fixed #91

### What changed
- Fixed a broken CLI documentation link in the migration guide.

### Why
- The existing link returned a 404, which could block users during migration.

### How to test
- Open the migration guide.
- Click the CLI documentation link and confirm it resolves correctly.

Resovled Video:

<video src="https://github.com/user-attachments/assets/d666ff5f-3c1a-452b-ae37-81199b88b2a9" controls></video>


