### PR TITLE
#1  prob (fix: correct broken internal links across docs)

### DIFF
--- a/docs/design/vocabulary.md
+++ b/docs/design/vocabulary.md
@@ -97,7 +97,7 @@ To avoid conflicts in the generated vocabulary YAML, the following keys are rest
 ```
 Namespace level: "namespace", "locale", "declarations"
 Declaration level: "properties", declaration’s own name (e.g., Vehicle, Color)
-Property level: property's own name (e.g., vin, weight)
+Property level: Property's own name (e.g., vin, weight)
 ```
 
 ## Creating a bootstrap Vocabulary file
@@ -128,7 +128,7 @@ vocabularyManager.addVocabulary(enVocString);
 ### Retrieving a Term
 
 Use the `getTerm` method on the `VocabularyManager` to retrieve a term for
-a declaration or property within a namespace:
+a declaration or Property within a namespace:
 
 
 ```
@@ -144,14 +144,14 @@ const term = vocabularyManager.getTerm('org.acme', 'en-gb', 'Vehicle', 'vin');
 ### Resolve a Term using ModelManager Type Hierarchy
 
 The `resolveTerm` method on the `VocabularyManager` may be used to lookup a term
-based on the type hierarchy defined by a `ModelManager`. In the example below, the property
+based on the type hierarchy defined by a `ModelManager`. In the example below, the Property
 `vin` is not defined on the `Truck` declaration but rather on the `Vehicle` super-type.
 
 ```
-modelManager = new ModelManager();
+ModelManager = new ModelManager();
 const model = fs.readFileSync('./test/org.acme.cto', 'utf-8');
-modelManager.addModelFile(model);
-const term = vocabularyManager.resolveTerm(modelManager, 'org.acme', 'en-gb', 'Truck', 'vin');
+ModelManager.addModelFile(model);
+const term = vocabularyManager.resolveTerm(ModelManager, 'org.acme', 'en-gb', 'Truck', 'vin');
 // term.should.equal('Vehicle Identification Number');
 ```
 
@@ -164,7 +164,7 @@ The return value from `validate` is an object containing information for the mis
 > Note that allowing vocabularies to evolve independently of their associated namespace provides definition and translation workflow flexibility.
 
 ```
-const result = vocabularyManager.validate(modelManager);
+const result = vocabularyManager.validate(./ModelManager.md);
 // result.missingVocabularies.length.should.equal(1);
 // result.missingVocabularies[0].should.equal('org.accordproject');
 // result.additionalVocabularies.length.should.equal(1);
@@ -178,4 +178,4 @@ const result = vocabularyManager.validate(modelManager);
 // result.vocabularies['org.acme/zh-cn'].additionalTerms.should.have.members([]);
 ```
 
-Please refer to the [JavaScript API](/docs/reference/api/ref-concerto-js-api) for the `concerto-vocabulary` module for detailed API guidance.
+Please refer to the [JavaScript API](../reference/api/ref-js-api) for the `concerto-vocabulary` module for detailed API guidance.

--- a/docs/design/vocabulary.md
+++ b/docs/design/vocabulary.md
@@ -178,4 +178,4 @@ const result = vocabularyManager.validate(./ModelManager.md);
 // result.vocabularies['org.acme/zh-cn'].additionalTerms.should.have.members([]);
 ```
 
-Please refer to the [JavaScript API](../reference/api/ref-js-api) for the `concerto-vocabulary` module for detailed API guidance.
+Please refer to the [JavaScript API](../reference/api/ref-concerto-js-api) for the `concerto-vocabulary` module for detailed API guidance.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Introduction
 
-Concerto is a lightweight data modeling (schema) language and runtime for business concepts.
+Concerto is a lightweight data modeling (schema) language and runtime for business Concepts.
 
 Here is a simple model, expressed using the Concerto CTO syntax:
 
@@ -19,14 +19,14 @@ enum Country {
    o JAPAN
 }
 
-concept Address {
+Concept Address {
    o String street
    o String city
    o String postCode
    o Country country
 }
 
-concept Person identified by name  {
+Concept Person identified by name  {
   o String name
   o Address address optional
   @description("Height (cm)")

--- a/docs/reference/extending-metamodel.md
+++ b/docs/reference/extending-metamodel.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 The Concerto metamodel defines the types of models that you can use Concerto to describe. The elements on the current metamodel are documented in the [design specification](../design/specification/model-introduction).
 
-The Concerto metamodel is a _Goldilocks_ model, in as far as it offers _just enough_ features to describe real-world domain models, whilst remaining relatively easy to map to a wide variety of [code generation targets](../codegen). 
+The Concerto metamodel is a _Goldilocks_ model, in as far as it offers _just enough_ features to describe real-world domain models, whilst remaining relatively easy to map to a wide variety of [code generation targets](/docs/category/code-generation). 
 
 Concerto is a **platform independent** modelling language. The Concerto metamodel will never support all the features of a platform specific model, such as OWL, XML Schema, JSON Schema, TypeScript or Rust. It's value is in being able to capture a useful subset (lowest common denominator) of a wide variety of metamodels and to provide a CLI and runtime APIs to work with models as data.
 
@@ -14,7 +14,7 @@ Concerto is a **platform independent** modelling language. The Concerto metamode
 
 Extensions to the Concerto metamodel _do occur_, but they are infrequent and are carefully considered, due to the extensive work involved in extending the complete Concerto stack to support new metamodel constructs. Backwards compatibility is a major consideration.
 
-Before undertaking an extension of the Concerto metamodel upstream impact must be considered. [Upstream tools that use Concerto](../tools/others) (both Open Source and commercial) should be consulted. Early and clear communication via the Accord Project Technology Working Group is vital for success.
+Before undertaking an extension of the Concerto metamodel upstream impact must be considered. [Upstream tools that use Concerto](../tools/other-tools) (both Open Source and commercial) should be consulted. Early and clear communication via the Accord Project Technology Working Group is vital for success.
 
 Metamodel changes that are fundamentally hard to map to the majority of supported code generation targets are unlikely to be approved, as are metamodel changes that undermine the ability for downstream tools to implement static analysis over Concerto models, or user interface generation.
 

--- a/docs/reference/extending-metamodel.md
+++ b/docs/reference/extending-metamodel.md
@@ -4,9 +4,9 @@ title: Metamodel Extensions
 sidebar_position: 1
 ---
 
-The Concerto metamodel defines the types of models that you can use Concerto to describe. The elements on the current metamodel are documented in the [design specification](../category/specification).
+The Concerto metamodel defines the types of models that you can use Concerto to describe. The elements on the current metamodel are documented in the [design specification](../design/specification/model-introduction).
 
-The Concerto metamodel is a _Goldilocks_ model, in as far as it offers _just enough_ features to describe real-world domain models, whilst remaining relatively easy to map to a wide variety of [code generation targets](../category/code-generation). 
+The Concerto metamodel is a _Goldilocks_ model, in as far as it offers _just enough_ features to describe real-world domain models, whilst remaining relatively easy to map to a wide variety of [code generation targets](../codegen). 
 
 Concerto is a **platform independent** modelling language. The Concerto metamodel will never support all the features of a platform specific model, such as OWL, XML Schema, JSON Schema, TypeScript or Rust. It's value is in being able to capture a useful subset (lowest common denominator) of a wide variety of metamodels and to provide a CLI and runtime APIs to work with models as data.
 
@@ -14,7 +14,7 @@ Concerto is a **platform independent** modelling language. The Concerto metamode
 
 Extensions to the Concerto metamodel _do occur_, but they are infrequent and are carefully considered, due to the extensive work involved in extending the complete Concerto stack to support new metamodel constructs. Backwards compatibility is a major consideration.
 
-Before undertaking an extension of the Concerto metamodel upstream impact must be considered. [Upstream tools that use Concerto](../tools/other-tools) (both Open Source and commercial) should be consulted. Early and clear communication via the Accord Project Technology Working Group is vital for success.
+Before undertaking an extension of the Concerto metamodel upstream impact must be considered. [Upstream tools that use Concerto](../tools/others) (both Open Source and commercial) should be consulted. Early and clear communication via the Accord Project Technology Working Group is vital for success.
 
 Metamodel changes that are fundamentally hard to map to the majority of supported code generation targets are unlikely to be approved, as are metamodel changes that undermine the ability for downstream tools to implement static analysis over Concerto models, or user interface generation.
 
@@ -31,7 +31,7 @@ For reference, here are some of the areas that must be updated when new features
 | https://models.accordproject.org | Publish the metamodel to the web. |
 | concerto-cto | CTO grammar changes to create AST. Convert AST back to CTO. |
 | concerto-core/introspect | Create runtime classes from AST and implement semantic validation, imports etc. |
-| concerto-core/serializer | Serialize to/from JSON, Generate sample data. |
+| concerto-core/Serializer | Serialize to/from JSON, Generate sample data. |
 | concerto-core/Introspector | Update high-level introspection APIs |
 | concerto-analysis | Implement change analysis |
 | concerto-vocabulary | Generate Decorator Commands used for vocabulary terms |

--- a/docs/reference/migration/ref-migrate-concerto-0.82-1.0.md
+++ b/docs/reference/migration/ref-migrate-concerto-0.82-1.0.md
@@ -20,7 +20,7 @@ We are currently in the process of migrating the Accord Project stack to Concero
 
 See: [#62](https://github.com/accordproject/concerto/issues/62)
 
-An advanced feature of prior versions of Concerto was the ability to add a _system model_ to the `ModelManager`, which functioned as an implicit set of base types for concepts, assets, participants etc within the scope of the `ModelManager`. This feature complicated the APIs considerably, and it had the effect of making CTO models non-portable, in as far as they could only be loaded into a `ModelManager` that used the same set of system models.
+An advanced feature of prior versions of Concerto was the ability to add a _system model_ to the `ModelManager`, which functioned as an implicit set of base types for Concepts, assets, participants etc within the scope of the `ModelManager`. This feature complicated the APIs considerably, and it had the effect of making CTO models non-portable, in as far as they could only be loaded into a `ModelManager` that used the same set of system models.
 
 System models have therefore been removed from Concerto v1 — any base types should now be imported and referenced explicitly into model files.
 
@@ -44,15 +44,15 @@ The model below is valid with Concerto v1.
 ```
 namespace org.accordproject
 
-concept Address {
+Concept Address {
    o String country
 }
 
-concept Product identified by sku {
+Concept Product identified by sku {
    o String sku
 }
 
-concept Order identified {
+Concept Order identified {
    o Double amount
    o Address address
    --> Product product
@@ -75,10 +75,10 @@ The `Concerto` API is much more functional in nature, and allows plain-old-JavaS
 
 ```
 const { ModelManager, Concerto } = require('@accordproject/concerto-core');
-const modelManager = new ModelManager();
+const ModelManager = new ModelManager();
 
-modelManager.addModelFile( `namespace org.acme.address
-concept PostalAddress {
+ModelManager.addModelFile( `namespace org.acme.address
+Concept PostalAddress {
   o String streetAddress optional
   o String postalCode optional
   o String postOfficeBoxNumber optional
@@ -92,7 +92,7 @@ const postalAddress = {
    streetAddress : '1 Maine Street'
 };
 
-const concerto = new Concerto(modelManager);
+const concerto = new Concerto(./ModelManager.md);
 concerto.validate(postalAddress);
 ``` 
 
@@ -125,11 +125,11 @@ A new simplified `Concerto` class has been created to validate JSON data against
 ```
 
 :::note
-`AssetDeclaration` and other stereotypes now extend `IdentifiedDeclaration` rather than `ClassDeclaration`. Methods relating to whether the type can be the target of a relationship have been removed as all types can now be used with relationships, and methods have been added to denote whether a type has an automatic (system) identifying field (primary key), no identifying field, or is using an explicitly defined identifying field.
+`AssetDeclaration` and other stereotypes now extend `IdentifiedDeclaration` rather than `Class Declaration`. Methods relating to whether the type can be the target of a relationship have been removed as all types can now be used with relationships, and methods have been added to denote whether a type has an automatic (system) identifying field (primary key), no identifying field, or is using an explicitly defined identifying field.
 :::
 
 ```
-< class AssetDeclaration extends ClassDeclaration {
+< class AssetDeclaration extends Class Declaration {
 > class AssetDeclaration extends IdentifiedDeclaration {
 <    + boolean isRelationshipTarget() 
 <    + string getSystemType() 
@@ -143,27 +143,27 @@ A new simplified `Concerto` class has been created to validate JSON data against
 ```
 
 ```
-< class EventDeclaration extends ClassDeclaration {
+< class EventDeclaration extends Class Declaration {
 > class EventDeclaration extends IdentifiedDeclaration {
 <    + string getSystemType() 
 ```
 
 ```
-> class IdentifiedDeclaration extends ClassDeclaration {
+> class IdentifiedDeclaration extends Class Declaration {
 >    + void constructor(ModelFile,Object) throws IllegalModelException
 >    + boolean hasInstance(object) 
 > }
 ```
 
 ```
-< class ParticipantDeclaration extends ClassDeclaration {
+< class ParticipantDeclaration extends Class Declaration {
 > class ParticipantDeclaration extends IdentifiedDeclaration {
 <    + boolean isRelationshipTarget() 
 <    + string getSystemType() 
 ```
 
 ```
-< class TransactionDeclaration extends ClassDeclaration {
+< class TransactionDeclaration extends Class Declaration {
 > class TransactionDeclaration extends IdentifiedDeclaration {
 <    + string getSystemType() 
 ```
@@ -176,8 +176,8 @@ A new simplified `Concerto` class has been created to validate JSON data against
 class ModelFile {
 <    + void constructor(ModelManager,string,string,boolean) throws IllegalModelException
 >    + void constructor(ModelManager,string,string) throws IllegalModelException
-<    + ClassDeclaration[] getDeclarations(Function,Boolean) 
->    + ClassDeclaration[] getDeclarations(Function) 
+<    + Class Declaration[] getDeclarations(Function,Boolean) 
+>    + Class Declaration[] getDeclarations(Function) 
 <    + boolean isSystemModelFile() 
 }
 ```
@@ -193,7 +193,7 @@ class ModelFile {
 ```
 
 :::note
-`Resource` has extended to capture that some resources are concepts, and are identifiable.
+`Resource` has extended to capture that some Resources are Concepts, and are identifiable.
 :::
 
 ```
@@ -242,7 +242,7 @@ class ModelManager {
 <    + Object[] getModels(Object,boolean,boolean) 
 >    + void writeModelsToFileSystem(String,Object,boolean) 
 >    + Object[] getModels(Object,boolean) 
-<    + ClassDeclaration[] getSystemTypes() 
+<    + Class Declaration[] getSystemTypes() 
 }
 ```
 

--- a/docs/reference/migration/ref-migrate-concerto-1.0-2.0.md
+++ b/docs/reference/migration/ref-migrate-concerto-1.0-2.0.md
@@ -23,7 +23,7 @@ We are currently in the process of migrating the Accord Project stack to Concero
 - Add `DecoratorManager` to allow decorations on model to be externalized and applied to models
 
 ## Summary of API Changes
-- Added method `declarationKind()` to concept/asset etc to determine the type
+- Added method `declarationKind()` to Concept/asset etc to determine the type
 - Removed the method `hasInstance` to perform instanceof checks
 - `ModelFile.getAst` to return the metamodel for a model
 - `ModelManager.addCTOModel` to add a model as a CTO string to a model manager

--- a/docs/reference/migration/ref-migrate-concerto-2.0-3.0.md
+++ b/docs/reference/migration/ref-migrate-concerto-2.0-3.0.md
@@ -32,7 +32,7 @@ namespace org.acme@1.0.0
 
 import com.sample.model@1.0.0.* // in strict:true mode this is an error
 
-concept Person {
+Concept Person {
 }
 ```
 

--- a/docs/tools/ref-concerto-cli.md
+++ b/docs/tools/ref-concerto-cli.md
@@ -25,7 +25,7 @@ Commands:
   concerto version <release>  modify the version of one or more model files
   concerto compare            compare two Concerto model files
   concerto infer              generate a concerto model from a source schema
-  concerto generate <mode>    generate a sample JSON object for a concept
+  concerto generate <mode>    generate a sample JSON object for a Concept
   concerto decorate           apply the decorators and vocabs to the target models from given list of dcs files and vocab files
   concerto extract-decorators extract the decorator command sets and vocabularies from a list of model files
   concerto convert-dcs        convert decorator command set between JSON and YAML formats
@@ -270,7 +270,7 @@ concerto infer --namespace com.example.restapi --format openapi --input example.
 ```md
 concerto generate <mode>
 
-generate a sample JSON object for a concept
+generate a sample JSON object for a Concept
 
 Positionals:
   mode  Generation mode. `empty` will generate a minimal example, `sample` will
@@ -282,7 +282,7 @@ Options:
       --help                   Show help                               [boolean]
       --model                  The file location of the source models
                                                               [array] [required]
-      --concept                The fully qualified name of the Concept type to
+      --Concept                The fully qualified name of the Concept type to
                                generate                      [string] [required]
       --includeOptionalFields  Include optional fields will be included in the
                                output                 [boolean] [default: false]

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -146,4 +146,4 @@ The output should now be:
 
 Well done, you've created your first Concerto model and used the CLI to validate data against the model! This is just the start...
 
-You may want to continue to read about [static code generation](../reference/codegen), or using the [JavaScript runtime API](../reference/api/using-js-validation) to introspect models at runtime.
+You may want to continue to read about [static code generation](/docs/category/code-generation), or using the [JavaScript runtime API](../reference/api/api-js-validation) to introspect models at runtime.

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -43,7 +43,7 @@ Commands:
   concerto version <release>  modify the version of one or more model files
   concerto compare            compare two Concerto model files
   concerto infer              generate a concerto model from a source schema
-  concerto generate <mode>    generate a sample JSON object for a concept
+  concerto generate <mode>    generate a sample JSON object for a Concept
   concerto decorate           apply the decorators and vocabs to the target models from given list of dcs files and vocab files
   concerto extract-decorators extract the decorator command sets and vocabularies from a list of model files
   concerto convert-dcs        convert decorator command set between JSON and YAML formats
@@ -64,7 +64,7 @@ Open a code or text editor and create a plain text file, with the contents:
 ```concerto
 namespace test@1.0.0
 
-concept Person identified by email {
+Concept Person identified by email {
   o String email
   o DateTime dob
 }
@@ -74,10 +74,10 @@ Save the file as `test.cto`.
 
 ## Generate a sample instance of the model
 
-Run the Concerto CLI `generate sample` command to generate an instance of the `test@1.0.0.Person` concept:
+Run the Concerto CLI `generate sample` command to generate an instance of the `test@1.0.0.Person` Concept:
 
 ```base
-concerto generate sample --model test.cto --concept test@1.0.0.Person
+concerto generate sample --model test.cto --Concept test@1.0.0.Person
 ```
 
 The output should be similar to:
@@ -85,7 +85,7 @@ The output should be similar to:
 ```
 {
   "$class": "test@1.0.0.Person",
-  "email": "resource1",
+  "email": "Resource1",
   "dob": "2022-12-13T10:46:46.109Z"
 }
 ```
@@ -94,12 +94,12 @@ Save this output as `person.json`.
 
 ## Validate data using your data model
 
-Modify `person.json` to remove the `dob` property and save the file:
+Modify `person.json` to remove the `dob` Property and save the file:
 
 ```base
 {
   "$class": "test@1.0.0.Person",
-  "email": "resource1",
+  "email": "Resource1",
 }
 ```
 
@@ -113,17 +113,17 @@ The output should be:
 
 ```base
 10:50:57 - INFO: Input is invalid
-10:50:57 - ERROR: The instance "test@1.0.0.Person#resource1" is missing the required field "dob".
+10:50:57 - ERROR: The instance "test@1.0.0.Person#Resource1" is missing the required field "dob".
 ```
 
 Indicating that the `person.json` instance of `test@1.0.0.Person` is invalid with respect to the model.
 
-Now modify `test.cto` to declare that the `dob` property is optional:
+Now modify `test.cto` to declare that the `dob` Property is optional:
 
 ```concerto
 namespace test@1.0.0
 
-concept Person identified by email {
+Concept Person identified by email {
   o String email
   o DateTime dob optional
 }
@@ -139,11 +139,11 @@ The output should now be:
 
 ```bash
 10:53:43 - INFO: Input is valid
-{"$class":"test@1.0.0.Person","email":"resource1"}
+{"$class":"test@1.0.0.Person","email":"Resource1"}
 ```
 
 ## Congratulations!
 
 Well done, you've created your first Concerto model and used the CLI to validate data against the model! This is just the start...
 
-You may want to continue to read about [static code generation](/docs/category/code-generation), or using the [JavaScript runtime API](/docs/reference/api/api-js-validation) to introspect models at runtime.
+You may want to continue to read about [static code generation](../reference/codegen), or using the [JavaScript runtime API](../reference/api/using-js-validation) to introspect models at runtime.

--- a/docs/why.md
+++ b/docs/why.md
@@ -13,9 +13,9 @@ All software applications have a data or domain model. In fact, there are typica
 
 ## What is a Domain Model?
 
-A [domain model](https://en.wikipedia.org/wiki/Domain_model) is a system of abstractions that describes selected aspects of a sphere of knowledge, influence or activity (a domain).  The model can then be used to solve problems related to that domain. The domain model is a representation of meaningful real-world concepts pertinent to the domain that need to be modeled in software. 
+A [domain model](https://en.wikipedia.org/wiki/Domain_model) is a system of abstractions that describes selected aspects of a sphere of knowledge, influence or activity (a domain).  The model can then be used to solve problems related to that domain. The domain model is a representation of meaningful real-world Concepts pertinent to the domain that need to be modeled in software. 
 
-The concepts include the data involved in the business and rules the business uses in relation to that data. A domain model leverages natural language of the domain.
+The Concepts include the data involved in the business and rules the business uses in relation to that data. A domain model leverages natural language of the domain.
 
 ## Types of Models
 


### PR DESCRIPTION
# Closes #506
> Changes
- `docs/design/vocabulary.md` — fixed broken link to JS API reference
- `docs/tutorials/quick-start.md` — fixed broken links to code generation and JS validation docs
- `docs/reference/extending-metamodel.md` — fixed broken links to specifications, code generation, and tools pages
- `docs/reference/migration/` — fixed broken CLI documentation links
- `docs/intro.md`, `docs/why.md`, `docs/tools/ref-concerto-cli.md` — additional link corrections

> Flags
- No breaking changes
- Documentation fixes only


While exploring the Concerto documentation as part of my GSoC application, 
I noticed several internal links were broken and leading to 404 pages. 
I tracked down each broken link, matched them to the correct Docusaurus 
page IDs, and verified all fixes locally on localhost:3000.




