### PR TITLE
fix: added file path and page URL field to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,22 +4,21 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
-
 <!--- Provide a general summary of the issue in the Title above -->
 # Bug Report 🐛
 <!--- Provide an expanded summary of the issue -->
-
 ## Expected Behavior
 <!--- Tell us what should happen -->
-
 ## Current Behavior
 <!--- Tell us what happens instead of the expected behavior -->
-
+## Documentation File Path or Page URL
+<!--- If this is a documentation issue, please provide the file path or page URL -->
+<!--- e.g. /docs/tutorials/quick-start.md or https://concerto.accordproject.org/docs/tutorials/quick-start -->
+- File path (if known): 
+- Page URL (if known): 
 ## Possible Solution
 <!--- Not obligatory, but suggest a fix/reason for the bug, -->
-
 ## Steps to Reproduce
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
 <!--- reproduce this bug. Include code to reproduce, if relevant -->
@@ -27,7 +26,6 @@ assignees: ''
 2.
 3.
 4.
-
 ## Context (Environment)
 <!--- How has this issue affected you? What are you trying to accomplish? -->
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
@@ -35,9 +33,7 @@ assignees: ''
  - OS: [e.g. macOS]
  - Browser: [e.g. Chrome, Safari]
  - Version: [e.g. 0.22.15]
-
 ## Detailed Description
 <!--- Provide a detailed description of the change or addition you are proposing -->
-
 ## Possible Implementation
 <!--- Not obligatory, but suggest an idea for implementing addition or change -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,22 +4,21 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
-
 <!--- Provide a general summary of the feature in the Title above -->
 # Feature Request 🛍️
 <!--- Provide an expanded summary of the feature -->
-
 ## Use Case
 <!--- Tell us what feature we should support and what should happen -->
-
+## Documentation File Path or Page URL
+<!--- If this relates to existing documentation, please provide the file path or page URL -->
+<!--- e.g. /docs/tutorials/quick-start.md or https://concerto.accordproject.org/docs/tutorials/quick-start -->
+- File path (if known): 
+- Page URL (if known): 
 ## Possible Solution
 <!--- Not obligatory, but suggest an implementation -->
-
 ## Context
 <!--- How has this issue affected you? What are you trying to accomplish? -->
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
-
 ## Detailed Description
-<!--- Provide a detailed description of the change or addition you are proposing -->
+< Provide a detailed description of the change or addition you are proposing -->


### PR DESCRIPTION
Closes #114

While working on contributions to this repo for GSoC, I kept running 
into the same problem — documentation issues didn't mention which file 
needed fixing, so I'd spend more time hunting for the right file than 
actually fixing it. Issue #90 is a good example of this.

So I went ahead and added a "Documentation File Path or Page URL" section 
to the bug report and feature request templates. It's a small change but 
I think it'll make a real difference for new contributors trying to get 
started quickly.

>  Changes
- `bug_report.md` — added "Documentation File Path or Page URL" section
- `feature_request.md` — added "Documentation File Path or Page URL" section


