### PR TITLE
fix(docs): correct broken internal links in vocabulary and quick-start

### DIFF
--- a/docs/design/vocabulary.md
+++ b/docs/design/vocabulary.md
@@ -178,4 +178,4 @@ const result = vocabularyManager.validate(modelManager);
 // result.vocabularies['org.acme/zh-cn'].additionalTerms.should.have.members([]);
 ```
 
-Please refer to the [JavaScript API](/docs/reference/api/ref-concerto-js-api) for the `concerto-vocabulary` module for detailed API guidance.
+Please refer to the [JavaScript API](../reference/api/ref-concerto-js-api) for the `concerto-vocabulary` module for detailed API guidance.

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -146,4 +146,4 @@ The output should now be:
 
 Well done, you've created your first Concerto model and used the CLI to validate data against the model! This is just the start...
 
-You may want to continue to read about [static code generation](/docs/category/code-generation), or using the [JavaScript runtime API](/docs/reference/api/api-js-validation) to introspect models at runtime.
+You may want to continue to read about [static code generation](/docs/category/code-generation), or using the [JavaScript runtime API](../reference/api/using-js-validation) to introspect models at runtime.


### PR DESCRIPTION
>  Description

While going through the docs 
I noticed two internal links were broken and leading to 404 pages.

After digging in, I found both were using absolute Docusaurus 
paths (`/docs/...`) instead of relative paths which is what 
was causing them to break.

Fixed the following:
- `docs/design/vocabulary.md`  the link to the JS API 
  reference was using `/docs/reference/api/ref-concerto-js-api`, 
 
  changed it to "../reference/api/ref-concerto-js-api"

- "docs/tutorials/quick-start.md " on line 149 the link to the JS 
  validation API was pointing to a non-existent page 
  `api-js-validation`, corrected it to `using-js-validation`

I have  verified both the fixe locally on localhost:3000, there are no 404s errors anymore.

very Sorry about the messy previous PR #122 — I had included some 
usless casing changes which were not needed  . This PR is 
focused  on the link fixes only.

## Author Checklist
- [x] DCO sign-off via  --signoff
- [x] commit messages follow AP format
- [x] docs only change, no tests needed
- [x] merging from `ospreyboi:fix/broken-links-506`

Closes #506

